### PR TITLE
Fix SC2155 warnings

### DIFF
--- a/installations-linker.sh
+++ b/installations-linker.sh
@@ -38,7 +38,8 @@ add_installation_to_path() {
             # Front-fill with spaces so all names are aligned
             local name_length=${#name}
             local spaces=$(( 15 - name_length ))
-            local spaces_string=$(printf "%${spaces}s" " ")
+            local spaces_string
+            spaces_string=$(printf "%${spaces}s" " ")
             spaces_string=${spaces_string// / }
 
             # echo -e "\e[32mAdded path to ${spaces_string} ${version} \e[0m"

--- a/installations/osu.sh
+++ b/installations/osu.sh
@@ -91,7 +91,8 @@ check_osu() {
 
     # results folder with date-stamp to avoid clobbering
     local results_root="$INSTALLS/osu/results"
-    local stamp=$(date +%Y-%m-%d_%H%M%S)
+    local stamp
+    stamp=$(date +%Y-%m-%d_%H%M%S)
     local results_dir="$results_root/$stamp"
     mkdir -p "$results_dir"
 

--- a/profession/sambitmishra98_pyfr/setup-worktree.sh
+++ b/profession/sambitmishra98_pyfr/setup-worktree.sh
@@ -140,10 +140,12 @@ EOF
 setup_worktree_testbed() {
     local RED='\e[31m' GREEN='\e[32m' YELLOW='\e[33m' BLUE='\e[34m' NC='\e[0m'
 
-    local caseloc=$(basename "$PWD")
+    local caseloc
+    caseloc=$(basename "$PWD")
 
     # Save the current directory
-    local current_dir=$(pwd)
+    local current_dir
+    current_dir=$(pwd)
 
 
     # Ensure we’re in testbed-<casename>


### PR DESCRIPTION
## Summary
- refactor SC2155 variable assignments in `installations-linker.sh`
- fix results timestamp assignment in `installations/osu.sh`
- split worktree var declarations in `setup-worktree.sh`

## Testing
- `shellcheck $(git ls-files '*.sh')`


------
https://chatgpt.com/codex/tasks/task_e_68419178a5b08326a65b92aa116a7206