### PR TITLE
Add consistent color utility

### DIFF
--- a/clusters/print-env-info.sh
+++ b/clusters/print-env-info.sh
@@ -3,13 +3,15 @@
 # Usage: source print-env-info.sh then call print_env_info
 # Requires: SLURM_JOB_NUM_NODES, SLURM_TASKS_PER_NODE variables
 
+source "$(dirname "${BASH_SOURCE[0]}")/../colors.sh"
+
 print_env_info() {
     mpi_tasks_per_node=$(echo "$SLURM_TASKS_PER_NODE" | sed -e 's/^\([0-9][0-9]*\).*$/\1/')
 
-    echo "Running on master node: $(hostname)"
-    echo "Time: $(date)"
-    echo "Current directory: $(pwd)"
-    echo -e "JobID: $SLURM_JOB_ID\n======"
-    echo -e "Tasks=${SLURM_NTASKS}, nodes=${SLURM_JOB_NUM_NODES}, MPI tasks per node=${mpi_tasks_per_node}"
+    echo -e "${BOLD}${BLUE}Running on master node:${RESET} $(hostname)"
+    echo -e "${BOLD}${BLUE}Time:${RESET} $(date)"
+    echo -e "${BOLD}${BLUE}Current directory:${RESET} $(pwd)"
+    echo -e "${MAGENTA}JobID:${RESET} $SLURM_JOB_ID\n${MAGENTA}======${RESET}"
+    echo -e "${CYAN}Tasks=${SLURM_NTASKS}, nodes=${SLURM_JOB_NUM_NODES}, MPI tasks per node=${mpi_tasks_per_node}${RESET}"
     #echo $PATH | tr ':' '\n'
 }

--- a/colors.sh
+++ b/colors.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Standard color variables for scripts
+RED='\e[31m'
+GREEN='\e[32m'
+YELLOW='\e[33m'
+BLUE='\e[34m'
+MAGENTA='\e[35m'
+CYAN='\e[36m'
+BOLD='\e[1m'
+RESET='\e[0m'


### PR DESCRIPTION
## Summary
- add `colors.sh` defining reusable color variables
- enhance cluster `print-env-info.sh` with color output
- unify colorized status messages in `installations/mpich.sh`

## Testing
- `shellcheck $(git ls-files '*.sh')`

------
https://chatgpt.com/codex/tasks/task_e_684194db597c8326954f01e7a760eb73